### PR TITLE
Adds "demoURL" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://mike.works/ember-resize"
   }
 }


### PR DESCRIPTION
Sites likes emberaddons.com and emberobserver.com will display a link to "demoURL".