### PR TITLE
Silence Deprecation Warning When Registering as Service

### DIFF
--- a/addon/services/resize.js
+++ b/addon/services/resize.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 
+const Base = Ember.Service || Ember.Object;
+
 const { classify } = Ember.String;
 
-export default Ember.Object.extend(Ember.Evented, {
-
+export default Base.extend(Ember.Evented, {
   _oldWidth: null,
   _oldHeight: null,
   _oldWidthDebounced: null,


### PR DESCRIPTION
Ember 1.13+ isn't thrilled that the resize service is being registered
as a service factory, but isn't extending from `Ember.Service`, or being
indicated as such.

This change resolves this deprecation. I opted not to extend
`Ember.Service` as that'd break users of this addon that are stuck on
Ember pre 1.10.